### PR TITLE
fix: double-digit countdown

### DIFF
--- a/crates/countdown/src/lib.rs
+++ b/crates/countdown/src/lib.rs
@@ -10,8 +10,10 @@ pub mod countdown {
     pub fn print_countdown(seconds: i64) {
         // countdown timer
         println!("Countdown timer: ");
+        let escape = "\x1b";
+        let erase_current_line = "[2K";
         for remaining in (0..=seconds).rev() {
-            print!("\r{} seconds remaining", remaining);
+            print!("\r{}{}{} seconds remaining", escape, erase_current_line, remaining);
             io::stdout().flush().unwrap();
             sleep(Duration::from_secs(1));
         }


### PR DESCRIPTION
fixed an issue where the double-digit (or greater) would start displaying the last "g" again. For example, when the display ouput was "10 seconds remaining", then the next display would be "9 seconds remainingg" ending with an addition "g". This commit fixes that.
