### PR TITLE
chore: deprecate the older print_countdown

### DIFF
--- a/crates/countdown/src/lib.rs
+++ b/crates/countdown/src/lib.rs
@@ -9,7 +9,8 @@ pub mod countdown {
 
     /// Countdown timer
     ///
-    /// This function takes a number of seconds to count down from and a callback function to call
+    /// This function takes a number of seconds to count down from and a callback function to call.
+    /// This is a blocking call.
     pub fn callback_countdown(seconds: i64, callback: fn(seconds: i64) -> ()) {
         for remaining in (0..=seconds).rev() {
             callback(remaining);
@@ -19,7 +20,13 @@ pub mod countdown {
 
     /// Countdown timer
     ///
-    /// This function takes a number of seconds to count down from and prints the countdown
+    /// This function takes a number of seconds to count down from and prints the countdown.
+    /// This is a blocking call.
+    ///
+    /// # Deprecated
+    ///
+    /// This function is deprecated. Use [`callback_countdown`] instead.
+    #[deprecated(since = "0.1.1", note = "Use callback_countdown instead")]
     pub fn print_countdown(seconds: i64) {
         // countdown timer
         println!("Countdown timer: ");

--- a/crates/example/src/main.rs
+++ b/crates/example/src/main.rs
@@ -1,18 +1,24 @@
-use countdown;
+use countdown::countdown::callback_countdown;
 use std::io::{self, Write};
 
 fn main() {
     // countdown timer
     println!("Countdown timer: ");
-    countdown::countdown::callback_countdown(20, |seconds| {
-        let escape = "\x1b";
-        let erase_current_line = "[2K";
+    callback_countdown(12, |seconds| {
+        let erase_current_line = "\x1b[2K";
+        let warning = match seconds {
+            // yellow
+            4..=10 => "\x1b[33m",
+            // red
+            0..=3 => "\x1b[31m",
+            // blue
+            _ => "\x1b[34m",
+        };
         print!(
-            "\r{}{}{} seconds remaining",
-            escape, erase_current_line, seconds
+            "\r{}{}{} seconds remaining\x1b[0m",
+            erase_current_line, warning, seconds
         );
         io::stdout().flush().unwrap();
     });
-    println!("\nTime's up!");
-    println!("Hello, world!");
+    println!("\n\x1b[1mTime's up!\x1b[0m");
 }


### PR DESCRIPTION
Officially deprecating the older print_countdown function. It is meant to be replaced with the callback_countdown function.
